### PR TITLE
Hide the border when not a sidebar

### DIFF
--- a/themes/cupper/static/css/styles.css
+++ b/themes/cupper/static/css/styles.css
@@ -842,6 +842,9 @@ h1 svg {
     .intro {
         text-align: center;
     }
+    .intro-and-nav {
+        border-right: none;
+    }
     .intro-and-nav > div {
         padding: 1.5rem;
     }


### PR DESCRIPTION
Just a small tweak: the border seems unnecessary when not serving as a dividing line between the sidebar and content.